### PR TITLE
Added auth controller and JWT token generation

### DIFF
--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -16,8 +16,8 @@ namespace PSP.Controllers
     public class AuthController : Controller
     {
         private readonly ICustomersService _service;
-
         private readonly IConfiguration _config;
+
         public AuthController(ICustomersService service, IConfiguration config)
         {
             _service = service;

--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -1,0 +1,57 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.AspNetCore.Authorization;
+using PSP.Models.DTOs;
+using PSP.Models.Entities;
+using PSP.Services.Interfaces;
+
+
+namespace PSP.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class AuthController : Controller
+    {
+        private readonly ICustomersService _service;
+
+        private readonly IConfiguration _config;
+        public AuthController(ICustomersService service, IConfiguration config)
+        {
+            _service = service;
+            _config = config;
+        }
+
+        [HttpPost("login")]
+        public ActionResult Login([FromBody] CustomerLogin body)
+        {
+            var currentUser = _service.Authenticate(body);
+            if(currentUser == null) 
+            {
+                return Unauthorized("Invalid username or password");
+            }
+
+            return Ok(GenerateToken(currentUser));
+        }
+
+        private string GenerateToken(Customer customer)
+        {
+            var securityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_config["Jwt:Key"]));
+            var credentials = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256);
+            var claims = new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, customer.Username)
+            };
+            var token = new JwtSecurityToken(_config["Jwt:Issuer"],
+                _config["Jwt:Audience"],
+                claims,
+                expires: DateTime.Now.AddHours(24),
+                signingCredentials: credentials);
+
+
+            return new JwtSecurityTokenHandler().WriteToken(token);
+        }
+    }
+}

--- a/Models/DTOs/CustomerLogin.cs
+++ b/Models/DTOs/CustomerLogin.cs
@@ -1,0 +1,8 @@
+﻿namespace PSP.Models.DTOs
+{
+    public class CustomerLogin
+    {
+        public string Username { get; set; }
+        public string Password { get; set; }
+    }
+}

--- a/Models/Entities/Customer.cs
+++ b/Models/Entities/Customer.cs
@@ -1,0 +1,20 @@
+﻿using System.ComponentModel.DataAnnotations.Schema;
+using System.ComponentModel.DataAnnotations;
+
+namespace PSP.Models.Entities
+{
+    public class Customer
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+
+        [Required]
+        public string? Username { get; set; }
+
+        [Required]
+        public string? Password { get; set; }
+
+        public ICollection<Order>? Orders { get; set; }
+    }
+}

--- a/Models/Entities/Customer.cs
+++ b/Models/Entities/Customer.cs
@@ -10,10 +10,10 @@ namespace PSP.Models.Entities
         public int Id { get; set; }
 
         [Required]
-        public string? Username { get; set; }
+        public string Username { get; set; }
 
         [Required]
-        public string? Password { get; set; }
+        public string Password { get; set; }
 
         public ICollection<Order>? Orders { get; set; }
     }

--- a/Models/Entities/PSPDatabaseContext.cs
+++ b/Models/Entities/PSPDatabaseContext.cs
@@ -7,10 +7,27 @@ public class PSPDatabaseContext : DbContext
     public PSPDatabaseContext(DbContextOptions<PSPDatabaseContext> options)
     : base(options)
     {
+        ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+        Database.EnsureCreated();
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<Customer>().HasData(
+            new Customer
+            {
+                Id = 1,
+                Username = "test",
+                Password = "123"
+            }
+        );
     }
 
     public DbSet<Order> Orders { get; set; } = null!;
     public DbSet<Service> Services { get; set; } = null!;
     public DbSet<ServiceSlot> ServiceSlots { get; set; } = null!;
     public DbSet<Cancellation> Cancellations { get; set; } = null!;
+    public DbSet<Customer> Customers { get; set; } = null!;
 }

--- a/PSP.csproj
+++ b/PSP.csproj
@@ -7,11 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.15" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.14" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.14" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.14" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.1.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.1.2" />
   </ItemGroup>
-
 </Project>

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,7 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
 using PSP;
 using PSP.Models.DTOs;
 using PSP.Models.Entities;
@@ -13,13 +16,31 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddDbContext<PSPDatabaseContext>(opt =>
     opt.UseInMemoryDatabase("PSP"));
 
+// Authentication
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme).AddJwtBearer(options => {
+    options.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuer = true,
+        ValidateAudience = true,
+        ValidateLifetime = true,
+        ValidateIssuerSigningKey = true,
+        ValidIssuer = builder.Configuration["Jwt:Issuer"],
+        ValidAudience = builder.Configuration["Jwt:Audience"],
+        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]))
+    };
+});
+
+// Repositories
 builder.Services.AddScoped<IBaseRepository<Service>, ServicesRepository>();
 builder.Services.AddScoped<IBaseRepository<ServiceSlot>, ServiceSlotsRepository>();
 builder.Services.AddScoped<IBaseRepository<Cancellation>, CancellationRepository>();
+builder.Services.AddScoped<IBaseRepository<Customer>, CustomersRepository>();
 
+// Services
 builder.Services.AddScoped<ICrudEntityService<Service, ServiceCreate>, ServicesService>();
 builder.Services.AddScoped<IServiceSlotsService, ServiceSlotsService>();
 builder.Services.AddScoped<ICrudEntityService<Cancellation, CancellationCreate>, CancellationService>();
+builder.Services.AddScoped<ICustomersService, CustomersService>();
 
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
@@ -39,6 +60,7 @@ app.UseMiddleware<ExceptionHandlingMiddleware>();
 
 app.UseHttpsRedirection();
 
+app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();

--- a/Repositories/CustomersRepository.cs
+++ b/Repositories/CustomersRepository.cs
@@ -1,0 +1,10 @@
+﻿using PSP.Models;
+using PSP.Models.Entities;
+
+namespace PSP.Repositories
+{
+    public class CustomersRepository : BaseRepository<Customer>
+    {
+        public CustomersRepository(PSPDatabaseContext dbContext) : base(dbContext) { }
+    }
+}

--- a/Services/CustomersService.cs
+++ b/Services/CustomersService.cs
@@ -1,0 +1,35 @@
+﻿using PSP.Models.DTOs;
+using PSP.Models.Entities;
+using PSP.Repositories;
+using PSP.Services.Interfaces;
+
+namespace PSP.Services
+{
+    public class CustomersService : CrudEntityService<Customer, CustomerLogin>, ICustomersService
+    {
+        public CustomersService(IBaseRepository<Customer> repository) : base(repository)
+        { }
+
+        public Customer Authenticate(CustomerLogin customerLoginDto)
+        {
+            var currentUser = _repository.GetQueryable().SingleOrDefault(user => user.Username.ToLower() ==
+                customerLoginDto.Username.ToLower() && user.Password == customerLoginDto.Password);
+            if (currentUser != null)
+            {
+                return currentUser;
+            }
+
+            return null;
+        }
+
+        protected override Customer ModelToEntity(CustomerLogin dto, int id = 0)
+        {
+            return new Customer()
+            {
+                Id = id,
+                Username = dto.Username,
+                Password = dto.Password,
+            };
+        }
+    }
+}

--- a/Services/CustomersService.cs
+++ b/Services/CustomersService.cs
@@ -14,12 +14,8 @@ namespace PSP.Services
         {
             var currentUser = _repository.GetQueryable().SingleOrDefault(user => user.Username.ToLower() ==
                 customerLoginDto.Username.ToLower() && user.Password == customerLoginDto.Password);
-            if (currentUser != null)
-            {
-                return currentUser;
-            }
 
-            return null;
+            return currentUser;
         }
 
         protected override Customer ModelToEntity(CustomerLogin dto, int id = 0)

--- a/Services/Interfaces/ICustomersService.cs
+++ b/Services/Interfaces/ICustomersService.cs
@@ -1,0 +1,10 @@
+﻿using PSP.Models.DTOs;
+using PSP.Models.Entities;
+
+namespace PSP.Services.Interfaces
+{
+    public interface ICustomersService : ICrudEntityService<Customer, CustomerLogin>
+    {
+        public Customer Authenticate(CustomerLogin userLoginDto);
+    }
+}

--- a/Services/ServicesService.cs
+++ b/Services/ServicesService.cs
@@ -1,6 +1,7 @@
 ﻿using PSP.Models.DTOs;
 using PSP.Models.Entities;
 using PSP.Repositories;
+using PSP.Services.Interfaces;
 
 namespace PSP.Services
 {

--- a/appsettings.json
+++ b/appsettings.json
@@ -5,5 +5,10 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Jwt": {
+    "Key": "rXmSacgkptXXdVre0BXRUZBjhZMQZl6G",
+    "Issuer": "http://localhost:36873",
+    "Audience": "http://localhost:36873"
+  }
 }


### PR DESCRIPTION
Added AuthController, Customer model and service. Controller only checks username and password in raw text, and if they match, it generates JWT token. Also seeding 

Even though document requirements specify /auth/logout endpoint, I decided not to implement it because JWT tokens expire on their own and is considered a bad practice to externally invalidate them or etc. Other option would be use other authentication method instead of JWT, but JWT is kinda uses mostly everywhere (for example google oauth uses it) and I'm a bit too lazy to redo it xd

TODO:
Review existing controllers and consider which require authentication and which don't
consider adding authorization (roles to Customer class, add role to JWT token and check it during controllers)